### PR TITLE
add text mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ A small, work-in-progress, offline<sup>1</sup> editor for custom star maps and c
 * improve performance for > 500 stars
 
 ### Maybe
-* constellation tracking
-* add text tool
-* optionally display star / constellation name
-* option to choose constellation starting point
-* pan / zoom on canvas and react to resize events
+* constellation: counting/tracking
+* star: display names
+* random: choose star as starting point for constellation
+* canvas: pan/zoom, react to resize events
+* text tool: fonts
 
 # References
 * CSS: [pico.css](https://picocss.com/)

--- a/index.html
+++ b/index.html
@@ -63,6 +63,12 @@
                 </a>
             </li>
             <li>
+                <a href="" id="mode-star-text" data-tooltip="Write Text to the Canvas [t]">
+                    <!-- remixicon "ri-text" -->
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path d="M13 6v15h-2V6H5V4h14v2z"/></svg>
+                </a>
+            </li>
+            <li>
                 <a href="" id="mode-star-delete" data-tooltip="Delete Stars or Lines [d]">
                     <!-- remixicon "ri-delete-bin-6-line" -->
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path d="M7 4V2h10v2h5v2h-2v15a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6H2V4h5zM6 6v14h12V6H6zm3 3h2v8H9V9zm4 0h2v8h-2V9z"/></svg>
@@ -369,6 +375,7 @@
                         <ul>
                             <li>Stars: <span id="num-stars">0</span></li>
                             <li>Lines: <span id="num-lines">0</span></li>
+                            <li>Texts: <span id="num-texts">0</span></li>
                         </ul>
 
                         <a href="https://github.com/tarenethil/astralarium/issues">Report an Issue</a>
@@ -397,6 +404,7 @@
                             <li><strong>i</strong>: Enter 'Add Star' Mode</li>
                             <li><strong>e</strong>: Enter 'Edit Star' Mode</li>
                             <li><strong>l</strong>: Enter 'Add Line' Mode</li>
+                            <li><strong>t</strong>: Enter 'Add Text' Mode</li>
                             <li><strong>d</strong>: Enter 'Delete' Mode</li>
                             <li><strong>Esc</strong>: Close Popup / Leave Mode</li>
                         </ul>


### PR DESCRIPTION
add mode to add (and also edit) text to the canvas. uses native size
controls instead of the slider because it feels more natural.

Signed-off-by: Thorben Römer <thorbenroemer@t-online.de>